### PR TITLE
更新B站滚屏代码

### DIFF
--- a/视频站h5.user.js
+++ b/视频站h5.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name             视频站启用html5播放器
 // @description      三大功能 。启用html5播放器；万能网页全屏；添加快捷键：快进、快退、暂停/播放、音量、下一集、切换(网页)全屏、上下帧、播放速度。支持视频站点：优.土、QQ、B站、新浪、微博、网易视频[娱乐、云课堂、新闻]、搜狐、乐视、风行、百度云视频等；直播：斗鱼、熊猫、YY、虎牙、龙珠。可自定义站点
-// @version          0.85
+// @version          0.85.1
 // @homepage         http://bbs.kafan.cn/thread-2093014-1-1.html
 // @include          *://pan.baidu.com/*
 // @include          *://yun.baidu.com/*
@@ -427,7 +427,7 @@ let router = {
 				setTimeout(_setPlayer, 300);
 				return;
 			}
-			w.scrollTo(0, v.closest('.player-wrapper,#bangumi_player').offsetTop);
+			w.scrollTo(0, v.closest('.player-box,#bangumi_player').offsetTop);
 			doClick(q('i.bilibili-player-iconfont-repeat.icon-24repeaton')); //关循环播放
 			// doClick(q('i[name=ctlbar_danmuku_close]'));//关弹幕
 			// 以下8行，自动播放


### PR DESCRIPTION
B站普通视频的播放器似乎改了class，原来的player-wrapper筛选不到播放器，我试了下新的播放器class似乎是player-box。另外我这里不能滚屏到位还连带影响到了自动播放，不知什么原理，总之这里改了一下之后就能工作正常了。测试环境Firefox 61.0 RC@Win10 x64 Pro