### PR TITLE
更新cntv脚本以适应cntv https化

### DIFF
--- a/cntv.user.js
+++ b/cntv.user.js
@@ -3,9 +3,9 @@
 // @namespace        xinggsf_CCAV
 // @description      CCAV视频启用html5
 // @version          0.0.6
-// @include          http://tv.cntv.cn/video/*
-// @include          http://*.cctv.com/*
-// @exclude          http://tv.cctv.com/live/cctv*
+// @include          http*://tv.cntv.cn/video/*
+// @include          http*://*.cctv.com/*
+// @exclude          http*://tv.cctv.com/live/cctv*
 // @noframes
 // @require          https://cdn.jsdelivr.net/npm/clappr@latest/dist/clappr.min.js
 // @require          https://cdn.jsdelivr.net/gh/clappr/clappr-level-selector-plugin@latest/dist/level-selector.min.js
@@ -41,8 +41,8 @@ class App {
 
 	async getVid() {
 		const url = location.href;
-		this.vid = r1(/^http:\/\/tv\.cntv\.cn\/video\/\w+\/(\w+)/, url) ||
-					r1(/^http:\/\/xiyou\.cctv\.com\/\w\-([\w\-]+)\.html/, url);
+		this.vid = r1(/^https:\/\/tv\.cntv\.cn\/video\/\w+\/(\w+)/, url) ||
+					r1(/^https:\/\/xiyou\.cctv\.com\/\w\-([\w\-]+)\.html/, url);
 
 		if (!this.vid) {
 			const resp = await fetch(url);
@@ -53,7 +53,7 @@ class App {
 	}
 
 	async fetchSrc() {
-		const resp = await xfetch('http://vdn.apps.cntv.cn/api/getHttpVideoInfo.do?pid=' + this.vid);
+		const resp = await xfetch('https://vdn.apps.cntv.cn/api/getHttpVideoInfo.do?pid=' + this.vid);
 		return resp.response;
 	}
 


### PR DESCRIPTION
cntv已经将页面上大部分链接替换为https，但http链接仍然存在。由于https的限制，从https页面请求http资源是不允许的。（反之，从http页面请求https资源是允许的）并且脚本默认不在https页面生效，因此会发生（1）https页面仍默认使用flash播放器（2）即使强制脚本在https页面生效，也会因解析到的视频内容是http流而被禁止加载。故特此更新此脚本以适应cntv的https化。